### PR TITLE
Update to support MIPS GCC up to version 11.1.0

### DIFF
--- a/build_env/makes/make_app
+++ b/build_env/makes/make_app
@@ -3,7 +3,7 @@ NC   =\033[0m # No Color
 
 INCLUDE           = ../../software/include
 
-CFLAGS            = -O2 -Wall -fms-extensions -c -s -std=c99 -G 0
+CFLAGS            = -fno-builtin -O2 -Wall -fms-extensions -c -s -std=c99 -G 0
 GCC_MIPS          = mips-elf-gcc $(CFLAGS)
 AS_MIPS           = mips-elf-as
 LD_MIPS           = mips-elf-ld
@@ -20,17 +20,17 @@ default: $(BOOT_TASK).o $(TASK_OBJ)
 
 boot_task.o: $(BOOT_TASK_SRC)
 	@printf "${GREEN}Compiling boot task: %s ...${NC}\n" "$*.c"
-	$(AS_MIPS) --defsym sp_addr=$(PAGE_SP_INIT) -o $@ $^
+	@$(AS_MIPS) --defsym sp_addr=$(PAGE_SP_INIT) -o $@ $^
 
 #[$*] - only the filename - #https://www.gnu.org/software/make/manual/make.html#Automatic-Variables
 $(TASK_OBJ): $(TASK_SRC) 
 	@printf "${GREEN}Compiling task: %s ...${NC}\n" "$*.c"
-	$(GCC_MIPS) $(CFLAGS) $*.c -o $*.o --include id_tasks.h -I $(INCLUDE)
-	$(LD_MIPS) --section-start=".init"=0 -Map $*.map -s -N -o $*.elf $(BOOT_TASK).o $*.o
-	$(LD_MIPS) --section-start=".init"=0 -Map $*_debug.map -o $*_debug.elf $(BOOT_TASK).o $*.o
-	$(DUMP_MIPS) -S $*_debug.elf > $*.lst
-	$(COPY_MIPS) -R .MIPS.abiflags -R .reginfo $*.elf $*.bin
-	hexdump -v -e '1/1 "%02x" 1/1 "%02x" 1/1 "%02x" 1/1 "%02x" "\n"' $*.bin > $*.txt
+	@$(GCC_MIPS) $(CFLAGS) $*.c -o $*.o --include id_tasks.h -I $(INCLUDE)
+	@$(LD_MIPS) --section-start=".init"=0 -Map $*.map -s -N -o $*.elf $(BOOT_TASK).o $*.o
+	@$(LD_MIPS) --section-start=".init"=0 -Map $*_debug.map -o $*_debug.elf $(BOOT_TASK).o $*.o
+	@$(DUMP_MIPS) -S $*_debug.elf > $*.lst
+	@$(COPY_MIPS) -R .MIPS.abiflags -R .reginfo $*.elf $*.bin
+	@hexdump -v -e '1/1 "%02x" 1/1 "%02x" 1/1 "%02x" 1/1 "%02x" "\n"' $*.bin > $*.txt
 
 clean:
 	@printf "Cleaning up\n"

--- a/build_env/makes/make_kernel
+++ b/build_env/makes/make_kernel
@@ -4,7 +4,7 @@ NC   =\033[0m # No Color
 KERNEL_PKG_TGT    = ../include/kernel_pkg.o
 KERNEL_PKG_SRC    = $(KERNEL_PKG_TGT:.o=.c) $(KERNEL_PKG_TGT:.o=.h)
 
-CFLAGS            = -O2 -Wall -fms-extensions -c -std=c99 -G 0
+CFLAGS            = -fno-builtin -Os -Wall -fms-extensions -c -std=c99 -G 0
 GCC_MIPS          = mips-elf-gcc $(CFLAGS)
 AS_MIPS           = mips-elf-as
 LD_MIPS           = mips-elf-ld
@@ -41,31 +41,31 @@ default: $(KERNEL_MASTER).txt $(KERNEL_SLAVE).txt
 
 $(KERNEL_PKG_TGT): $(KERNEL_PKG_SRC)
 	@printf "${RED}Compiling Kernel Package: %s ...${NC}\n" "$*.c"
-	$(GCC_MIPS) -o $*.o $*.c
+	@$(GCC_MIPS) -o $*.o $*.c
 
 $(MODULES_TGT): $(MODULES_SRC)
 	@printf "${RED}Compiling Kernel %s ...${NC}\n" "$*.c"
-	$(GCC_MIPS) -o $*.o $*.c
+	@$(GCC_MIPS) -o $*.o $*.c
 
 $(KERNEL_MASTER).txt: $(KERNEL_PKG_TGT) $(MODULES_TGT) $(KERNEL_MASTER_SRC) $(KERNEL_MASTER_H) $(BOOT_MASTER_SRC)
 	@printf "${RED}Compiling Kernel Master: %s ...${NC}\n" "$(KERNEL_MASTER).c" 
-	$(AS_MIPS) --defsym sp_addr=$(MEM_SP_INIT) -o $(BOOT_MASTER).o $(BOOT_MASTER_SRC)
-	$(GCC_MIPS) -DHOP_NUMBER=1 -Dload -o $(KERNEL_MASTER).o $(KERNEL_MASTER_SRC) -D IS_MASTER
-	$(LD_MIPS) --section-start=".init"=0 -Map $(KERNEL_MASTER).map -s -N -o $(KERNEL_MASTER).elf $(BOOT_MASTER).o $(KERNEL_MASTER).o $(KERNEL_MASTER_TGT) $(KERNEL_PKG_TGT)
-	$(LD_MIPS) --section-start=".init"=0 -Map $(KERNEL_MASTER)_debug.map -o $(KERNEL_MASTER)_debug.elf $(BOOT_MASTER).o $(KERNEL_MASTER).o $(KERNEL_MASTER_TGT) $(KERNEL_PKG_TGT)
-	$(DUMP_MIPS) -S $(KERNEL_MASTER)_debug.elf > $(KERNEL_MASTER).lst
-	$(COPY_MIPS) -R .MIPS.abiflags -R .reginfo $(KERNEL_MASTER).elf $(KERNEL_MASTER).bin
-	hexdump -v -e '1/1 "%02x" 1/1 "%02x" 1/1 "%02x" 1/1 "%02x" "\n"' $(KERNEL_MASTER).bin > $(KERNEL_MASTER).txt
+	@$(AS_MIPS) --defsym sp_addr=$(MEM_SP_INIT) -o $(BOOT_MASTER).o $(BOOT_MASTER_SRC)
+	@$(GCC_MIPS) -DHOP_NUMBER=1 -Dload -o $(KERNEL_MASTER).o $(KERNEL_MASTER_SRC) -D IS_MASTER
+	@$(LD_MIPS) --section-start=".init"=0 -Map $(KERNEL_MASTER).map -s -N -o $(KERNEL_MASTER).elf $(BOOT_MASTER).o $(KERNEL_MASTER).o $(KERNEL_MASTER_TGT) $(KERNEL_PKG_TGT)
+	@$(LD_MIPS) --section-start=".init"=0 -Map $(KERNEL_MASTER)_debug.map -o $(KERNEL_MASTER)_debug.elf $(BOOT_MASTER).o $(KERNEL_MASTER).o $(KERNEL_MASTER_TGT) $(KERNEL_PKG_TGT)
+	@$(DUMP_MIPS) -S $(KERNEL_MASTER)_debug.elf > $(KERNEL_MASTER).lst
+	@$(COPY_MIPS) -R .MIPS.abiflags -R .reginfo $(KERNEL_MASTER).elf $(KERNEL_MASTER).bin
+	@hexdump -v -e '1/1 "%02x" 1/1 "%02x" 1/1 "%02x" 1/1 "%02x" "\n"' $(KERNEL_MASTER).bin > $(KERNEL_MASTER).txt
 
 $(KERNEL_SLAVE).txt: $(KERNEL_PKG_TGT) $(MODULES_TGT) $(KERNEL_SLAVE_SRC) $(KERNEL_SLAVE_H) $(BOOT_SLAVE_SRC)
 	@printf "${RED}Compiling Kernel Slave: %s ...${NC}\n" "$(KERNEL_SLAVE).c"
-	$(AS_MIPS) --defsym sp_addr=$(PAGE_SP_INIT) -o $(BOOT_SLAVE).o $(BOOT_SLAVE_SRC)
-	$(GCC_MIPS) -o $(KERNEL_SLAVE).o $(KERNEL_SLAVE_SRC) -D PLASMA
-	$(LD_MIPS) --section-start=".init"=0 -Map $(KERNEL_SLAVE).map -s -N -o $(KERNEL_SLAVE).elf $(BOOT_SLAVE).o $(KERNEL_SLAVE).o $(KERNEL_SLAVE_TGT) $(KERNEL_PKG_TGT)
-	$(LD_MIPS) --section-start=".init"=0 -Map $(KERNEL_SLAVE)_debug.map -o $(KERNEL_SLAVE)_debug.elf $(BOOT_SLAVE).o $(KERNEL_SLAVE).o $(KERNEL_SLAVE_TGT) $(KERNEL_PKG_TGT)
-	$(DUMP_MIPS) -S $(KERNEL_SLAVE)_debug.elf > $(KERNEL_SLAVE).lst
-	$(COPY_MIPS) -R .MIPS.abiflags -R .reginfo $(KERNEL_SLAVE).elf $(KERNEL_SLAVE).bin
-	hexdump -v -e '1/1 "%02x" 1/1 "%02x" 1/1 "%02x" 1/1 "%02x" "\n"' $(KERNEL_SLAVE).bin > $(KERNEL_SLAVE).txt
+	@$(AS_MIPS) --defsym sp_addr=$(PAGE_SP_INIT) -o $(BOOT_SLAVE).o $(BOOT_SLAVE_SRC)
+	@$(GCC_MIPS) -o $(KERNEL_SLAVE).o $(KERNEL_SLAVE_SRC) -D PLASMA
+	@$(LD_MIPS) --section-start=".init"=0 -Map $(KERNEL_SLAVE).map -s -N -o $(KERNEL_SLAVE).elf $(BOOT_SLAVE).o $(KERNEL_SLAVE).o $(KERNEL_SLAVE_TGT) $(KERNEL_PKG_TGT)
+	@$(LD_MIPS) --section-start=".init"=0 -Map $(KERNEL_SLAVE)_debug.map -o $(KERNEL_SLAVE)_debug.elf $(BOOT_SLAVE).o $(KERNEL_SLAVE).o $(KERNEL_SLAVE_TGT) $(KERNEL_PKG_TGT)
+	@$(DUMP_MIPS) -S $(KERNEL_SLAVE)_debug.elf > $(KERNEL_SLAVE).lst
+	@$(COPY_MIPS) -R .MIPS.abiflags -R .reginfo $(KERNEL_SLAVE).elf $(KERNEL_SLAVE).bin
+	@hexdump -v -e '1/1 "%02x" 1/1 "%02x" 1/1 "%02x" 1/1 "%02x" "\n"' $(KERNEL_SLAVE).bin > $(KERNEL_SLAVE).txt
 
 clean:
 	@printf "Cleaning up\n"

--- a/build_env/makes/make_systemc
+++ b/build_env/makes/make_systemc
@@ -39,35 +39,35 @@ all: $(MEMPHIS_TGT)
 
 $(MEMPHIS_TGT): $(ROUTER_TGT) $(PROCESSOR_TGT) $(DMNI_TGT) $(MEMORY_TGT) $(PE_TGT) $(IO_TGT) $(TOP_TGT)
 	@printf "${COR}Generating %s ...${NC}\n" "$@"
-	g++ -I./ -o $@ $^ -L. -L$(SYSTEMC_HOME)/lib-linux64 -lsystemc
+	@g++ -I./ -o $@ $^ -L. -L$(SYSTEMC_HOME)/lib-linux64 -lsystemc
 	
 $(TOP_TGT): $(TOP_SRC)
 	@printf "${COR}Compiling SystemC source: %s ...${NC}\n" "$(dir $<)$*.cpp"
-	$(SC_C) $(dir $<)$*.cpp
+	@$(SC_C) $(dir $<)$*.cpp
 	
 $(IO_TGT): $(IO_SRC)
 	@printf "${COR}Compiling SystemC source: %s ...${NC}\n" "$(dir $<)$(notdir $*).cpp"
-	$(SC_C) $(dir $<)$(notdir $*).cpp
+	@$(SC_C) $(dir $<)$(notdir $*).cpp
 
 $(PE_TGT): $(PE_SRC)
 	@printf "${COR}Compiling SystemC source: %s ...${NC}\n" "$(dir $<)$*.cpp"
-	$(SC_C) $(dir $<)$*.cpp
+	@$(SC_C) $(dir $<)$*.cpp
 
 $(DMNI_TGT): $(DMNI_SRC)
 	@printf "${COR}Compiling SystemC source: %s ...${NC}\n" "$(dir $<)$*.cpp"
-	$(SC_C) $(dir $<)$*.cpp
+	@$(SC_C) $(dir $<)$*.cpp
 
 $(MEMORY_TGT): $(MEMORY_SRC)
 	@printf "${COR}Compiling SystemC source: %s ...${NC}\n" "$(dir $<)$*.cpp"
-	$(SC_C) $(dir $<)$*.cpp
+	@$(SC_C) $(dir $<)$*.cpp
 
 $(PROCESSOR_TGT): $(PROCESSOR_SRC)
 	@printf "${COR}Compiling SystemC source: %s ...${NC}\n" "$(dir $<)$*.cpp"
-	$(SC_C) $(dir $<)$*.cpp
+	@$(SC_C) $(dir $<)$*.cpp
 
 $(ROUTER_TGT): $(ROUTER_SRC)
 	@printf "${COR}Compiling SystemC source: %s ...${NC}\n" "$(dir $<)$*.cpp"
-	$(SC_C) $(dir $<)$*.cpp
+	@$(SC_C) $(dir $<)$*.cpp
 	
 
 clean:

--- a/hardware/sc/pe/memory/ram.cpp
+++ b/hardware/sc/pe/memory/ram.cpp
@@ -23,7 +23,7 @@ void ram::load_ram(){
 	string line;
 	int i = 0;
 
-	char ram_path[20];
+	char ram_path[27];
 	sprintf(ram_path, "ram_pe/ram%dx%d.txt", (router_address >> 8), (router_address & 0xFF));
 	ifstream repo_file (ram_path);
 

--- a/software/kernel/slave/kernel_slave.c
+++ b/software/kernel/slave/kernel_slave.c
@@ -360,7 +360,7 @@ int Syscall(unsigned int service, unsigned int arg0, unsigned int arg1, unsigned
 					msg_write_pipe.length = msg_read->length;
 
 					//Avoids message overwriting by the producer task
-					for (int i=0; i < msg_read->length; i++)
+					for (volatile int i=0; i < msg_read->length; i++)
 						msg_write_pipe.msg[i] = msg_read->msg[i];
 
 					send_message_delivery(producer_task, consumer_task, msg_req_ptr->requester_proc, &msg_write_pipe);
@@ -419,7 +419,7 @@ int Syscall(unsigned int service, unsigned int arg0, unsigned int arg1, unsigned
 
 					msg_write->length = pipe_ptr->message.length;
 
-					for (int i = 0; i<msg_write->length; i++) {
+					for (volatile int i = 0; i<msg_write->length; i++) {
 						msg_write->msg[i] = pipe_ptr->message.msg[i];
 					}
 
@@ -550,7 +550,7 @@ void printTaskInformations(TCB *task_tcb, char text, char bss_data, char stack){
 
 	if (text){
 		puts("\nTEXT\n");
-		offset = task_tcb->offset;
+		offset = (unsigned int *)(task_tcb->offset);
 		for(i=0; i<task_tcb->text_lenght; i++){
 			puts(itoh(offset[i])); puts("\n");
 		}
@@ -558,7 +558,7 @@ void printTaskInformations(TCB *task_tcb, char text, char bss_data, char stack){
 
 	if (bss_data){
 		puts("\nBSS E DATA\n");
-		offset = (task_tcb->offset + (task_tcb->text_lenght*4));
+		offset = (unsigned int*)(task_tcb->offset + (task_tcb->text_lenght*4));
 		for(i=0; i<task_tcb->bss_lenght + task_tcb->data_lenght; i++){
 			puts(itoh(offset[i])); puts("\n");
 		}
@@ -566,7 +566,7 @@ void printTaskInformations(TCB *task_tcb, char text, char bss_data, char stack){
 
 	if (stack) {
 		puts("\nSTACK\n");
-		offset = task_tcb->offset + task_tcb->reg[25];
+		offset = (unsigned int*)(task_tcb->offset + task_tcb->reg[25]);
 		for(i=0; i<stack_lenght; i++){
 			puts(itoh(offset[i])); puts("\n");
 		}

--- a/software/modules/communication.c
+++ b/software/modules/communication.c
@@ -89,7 +89,7 @@ int add_PIPE(int producer_task, int consumer_task, Message * msg){
 
 	pipe_ptr->order = last_order + 1;
 
-	for (int i=0; i<msg->length; i++){
+	for (volatile int i=0; i<msg->length; i++){
 		pipe_ptr->message.msg[i] = msg->msg[i];
 	}
 

--- a/software/modules/pending_service.c
+++ b/software/modules/pending_service.c
@@ -44,7 +44,20 @@ unsigned char add_pending_service(ServiceHeader * pending_service){
 	fifo_free_position = &pending_services_FIFO[pending_service_last];
 
 	//equivalent to a memcopy once both are the same struct
-	*fifo_free_position = *pending_service;
+	/* Copy manually to avoid generating a memcpy */
+	fifo_free_position->header = pending_service->header;
+	fifo_free_position->payload_size = pending_service->payload_size;
+	fifo_free_position->service = pending_service->service;
+	fifo_free_position->producer_task = pending_service->producer_task;
+	fifo_free_position->consumer_task = pending_service->consumer_task;
+	fifo_free_position->source_PE = pending_service->source_PE;
+	fifo_free_position->timestamp = pending_service->timestamp;
+	fifo_free_position->transaction = pending_service->transaction;
+	fifo_free_position->msg_lenght = pending_service->msg_lenght;
+	fifo_free_position->pkt_size = pending_service->pkt_size;
+	fifo_free_position->code_size = pending_service->code_size;
+	fifo_free_position->bss_size = pending_service->bss_size;
+	fifo_free_position->initial_address = pending_service->initial_address;
 
 	if (pending_service_last == PENDING_SERVICE_TAM-1){
 		pending_service_last = 0;

--- a/software/modules/task_scheduler.c
+++ b/software/modules/task_scheduler.c
@@ -100,7 +100,7 @@ void clear_scheduling(Scheduling * scheduling_tcb){
  *  \param input_task Scheduling structure of the task to be updated
  *  \param current_time Current system time
  */
-void inline update_slack_time(Scheduling * input_task, unsigned int current_time){
+void update_slack_time(Scheduling * input_task, unsigned int current_time){
 
 	int relative_deadline, time_until_deadline;
 
@@ -194,7 +194,7 @@ unsigned int round_robin(){
  * \param scheduled Scheduled task pointer
  * \param time Current system time
  */
-void inline dynamic_slice_time(Scheduling *scheduled, unsigned int time){
+void dynamic_slice_time(Scheduling *scheduled, unsigned int time){
 
 	Scheduling * task;
 	unsigned int closer_period, second_LST, end_period;
@@ -238,7 +238,7 @@ void inline dynamic_slice_time(Scheduling *scheduled, unsigned int time){
  * status, slack-time
  *  \param current_time Current system time
  */
-void inline update_real_time(unsigned int current_time){
+void update_real_time(unsigned int current_time){
 
 	Scheduling * task;
 


### PR DESCRIPTION
This update does not break compatibility with bundled GCC 4.1.1